### PR TITLE
Override bing market

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,23 @@ Here we can get data in any of the formats but substituting the value of **forma
 
 **idx** denotes the *day before the current day*. idx=0 means current day, idx=1 means yesterday and so on.
 **n** is an integer denoting the *number of days before the day denoted by idx*. It grabs data about all the n number of images.
-**mkt** denotes the *area*. The script will try to match your locale to one of the supported Bing Market areas, falling back to 'en-US' if it fails to do so.
+**mkt** denotes the *area*. The script will try to match your locale to one of the supported Bing Market areas, falling back to 'en-US' if it fails to do so. You can also force a particular market area (see list of valid markets in https://msdn.microsoft.com/en-us/library/dd251064.aspx) in the config file:
+
+```
+~/.config/bing-desktop-wallpaper-changer/config.ini
+```
+
+Example:
+
+```
+[market]
+# If you want to override the current Bing market dectection,
+# set your preferred market here. For a list of markets, see
+# https://msdn.microsoft.com/en-us/library/dd251064.aspx
+area = 'bg-BG'
+```
+
+To force your area to be 'bg-BG' (Bulgarian - Bulgaria).
 
 All the wallpapers are stored in '**/home/[user]/Pictures/BingWallpapers/**'
 

--- a/main.py
+++ b/main.py
@@ -82,28 +82,32 @@ BING_MARKETS = [u'ar-XA',
                 u'zh-HK',
                 u'zh-TW']
 
-
-class BackgroundChanger(object):
-    SCHEMA = 'org.gnome.desktop.background'
-    KEY = 'picture-uri'
-
-    def change_background(self, filename):
-        gsettings = Gio.Settings.new(self.SCHEMA)
-        gsettings.set_string(self.KEY, "file://" + filename)
-        gsettings.apply()
-
-    def change_screensaver(self, filename):
-        gsettings = Gio.Settings.new('org.gnome.desktop.screensaver')
-        gsettings.set_string('picture-uri', 'file://' + filename)
-        gsettings.apply()
-
-
 config_file_skeleton = """[market]
 # If you want to override the current Bing market dectection,
 # set your preferred market here. For a list of markets, see
 # https://msdn.microsoft.com/en-us/library/dd251064.aspx
 area =
 """
+
+
+def get_file_uri(filename):
+    return 'file://%s' % filename
+
+
+def set_gsetting(schema, key, value):
+    gsettings = Gio.Settings.new(schema)
+    gsettings.set_string(key, value)
+    gsettings.apply()
+
+
+def change_background(filename):
+    set_gsetting('org.gnome.desktop.background', 'picture-uri',
+                 get_file_uri(filename))
+
+
+def change_screensaver(filename):
+    set_gsetting('org.gnome.desktop.screensaver', 'picture-uri',
+                 get_file_uri(filename))
 
 
 def get_config_file():
@@ -266,9 +270,8 @@ def main():
 
         if not os.path.isfile(image_path):
             urlretrieve(image_url, image_path)
-            bg_changer = BackgroundChanger()
-            bg_changer.change_background(image_path)
-            bg_changer.change_screensaver(image_path)
+            change_background(image_path)
+            change_screensaver(image_path)
             summary = 'Bing Wallpaper updated successfully'
             body = image_metadata.find("copyright").text.encode('utf-8')
         else:

--- a/main.py
+++ b/main.py
@@ -5,11 +5,11 @@ import locale
 import os
 import re
 import sys
-try: #try python 3 import
+try:  # try python 3 import
     from urllib.request import urlopen
     from urllib.request import urlretrieve
     from configparser import ConfigParser
-except ImportError: #fall back to python2
+except ImportError:  # fall back to python2
     from urllib import urlretrieve
     from urllib2 import urlopen
     from ConfigParser import ConfigParser
@@ -24,7 +24,7 @@ from gi.repository import Gtk
 from gi.repository import Notify
 
 
-class BackgroundChanger():
+class BackgroundChanger(object):
     SCHEMA = 'org.gnome.desktop.background'
     KEY = 'picture-uri'
 
@@ -36,7 +36,7 @@ class BackgroundChanger():
     def change_screensaver(self, filename):
         gsettings = Gio.Settings.new('org.gnome.desktop.screensaver')
         gsettings.set_string('picture-uri', 'file://' + filename)
-        gsettings.apply();
+        gsettings.apply()
 
 
 config_file_skeleton = """[market]
@@ -125,8 +125,10 @@ def get_screen_resolution_str():
 
     :return: String with your current screen resolution.
     """
-    sizes = [[800,[600]],[1024,[768]],[1280,[720,768]],[1366,[768]],[1920,[1080,1200]]]
-    sizes_mobile = [[768,[1024]],[720,[1280]],[768,[1280,1366]],[1080,[1920]]]
+    sizes = [[800, [600]], [1024, [768]], [1280, [720, 768]],
+             [1366, [768]], [1920, [1080, 1200]]]
+    sizes_mobile = [[768, [1024]], [720, [1280]],
+                    [768, [1280, 1366]], [1080, [1920]]]
     window = Gtk.Window()
     screen = window.get_screen()
     nmons = screen.get_n_monitors()
@@ -143,20 +145,20 @@ def get_screen_resolution_str():
             if mg.width > maxw or mg.height > maxw:
                 maxw = mg.width
                 maxh = mg.height
-    if maxw>maxh:
+    if maxw > maxh:
         v_array = sizes
     else:
         v_array = sizes_mobile
     for m in v_array:
-        if (maxw<=m[0]):
+        if maxw <= m[0]:
             sizew = m[0]
-            sizeh = m[1][len(m[1])-1]
+            sizeh = m[1][len(m[1]) - 1]
             for e in m[1]:
-                if (maxh<=e):
+                if maxh <= e:
                     sizeh = e
                     break
             break
-    
+
     return r'%sx%s' % (sizew, sizeh)
 
 

--- a/main.py
+++ b/main.py
@@ -23,6 +23,65 @@ from gi.repository import Gio
 from gi.repository import Gtk
 from gi.repository import Notify
 
+BING_MARKETS = [u'ar-XA',
+                u'bg-BG',
+                u'cs-CZ',
+                u'da-DK',
+                u'de-AT',
+                u'de-CH',
+                u'de-DE',
+                u'el-GR',
+                u'en-AU',
+                u'en-CA',
+                u'en-GB',
+                u'en-ID',
+                u'en-IE',
+                u'en-IN',
+                u'en-MY',
+                u'en-NZ',
+                u'en-PH',
+                u'en-SG',
+                u'en-US',
+                u'en-XA',
+                u'en-ZA',
+                u'es-AR',
+                u'es-CL',
+                u'es-ES',
+                u'es-MX',
+                u'es-US',
+                u'es-XL',
+                u'et-EE',
+                u'fi-FI',
+                u'fr-BE',
+                u'fr-CA',
+                u'fr-CH',
+                u'fr-FR',
+                u'he-IL',
+                u'hr-HR',
+                u'hu-HU',
+                u'it-IT',
+                u'ja-JP',
+                u'ko-KR',
+                u'lt-LT',
+                u'lv-LV',
+                u'nb-NO',
+                u'nl-BE',
+                u'nl-NL',
+                u'pl-PL',
+                u'pt-BR',
+                u'pt-PT',
+                u'ro-RO',
+                u'ru-RU',
+                u'sk-SK',
+                u'sl-SL',
+                u'sv-SE',
+                u'th-TH',
+                u'tr-TR',
+                u'uk-UA',
+                u'zh-CN',
+                u'zh-HK',
+                u'zh-TW']
+
 
 class BackgroundChanger(object):
     SCHEMA = 'org.gnome.desktop.background'
@@ -45,23 +104,6 @@ config_file_skeleton = """[market]
 # https://msdn.microsoft.com/en-us/library/dd251064.aspx
 area =
 """
-
-
-def get_valid_bing_markets():
-    """
-    Find valid Bing markets for area auto detection.
-
-    :see: https://msdn.microsoft.com/en-us/library/dd251064.aspx
-    :return: List with valid Bing markets (list looks like a list of locales).
-    """
-    url = 'https://msdn.microsoft.com/en-us/library/dd251064.aspx'
-    page = urlopen(url)
-    page_xml = ET.parse(page).getroot()
-    # Look in the table data
-    market = page_xml.findall('td')
-    market_locales = [el[1].text.strip() for el in enumerate(market) if
-                      el[0] % 2 == 0]
-    return market_locales
 
 
 def get_config_file():
@@ -99,7 +141,7 @@ def get_market():
         return market_area_override
 
     default_locale = locale.getdefaultlocale()[0]
-    if default_locale in get_valid_bing_markets():
+    if default_locale in BING_MARKETS:
         return default_locale
 
     return 'en-US'


### PR DESCRIPTION
Extra functionality to override bing market area, PEP8 fixes, and use a fixed list of valid Bing markets instead of parsing the MSDN page every script execution.
