### PR TITLE
Stop relying on bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ All the wallpapers are stored in '**/home/[user]/Pictures/BingWallpapers/**'
 
 Clone/download project (or just the main.py file)
 
-Replace "/path/to/Bing_Wallpapers" in the file bing_wallpapers.sh with the actual path to the folder Bing_Wallpapers that you've just cloned or unpacked after downloading.
+Replace "/path/to/Bing_Wallpapers" in the file main.py with the actual path to the folder Bing_Wallpapers that you've just cloned or unpacked after downloading.
 
 #### Autostart With gnome-session-properties
 Then add the script as a startup application. Type in terminal
@@ -47,7 +47,7 @@ gnome-session-properties
 then add a startup program as:
 ```plaintext
 Name: BingWallpaperChanger
-Command: /path/to/bing_wallpapers.sh
+Command: /path/to/main.py
 Comment: Automatically changes desktop wallpaper!
 ```
 
@@ -65,7 +65,7 @@ the file contents look like:
 [Desktop Entry]
 Type=Application
 Terminal=false
-Exec=/path/to/bing_wallpapers.sh
+Exec=/path/to/main.py
 Name=Bing Desktop Wallpaper Changer
 ```
 
@@ -83,7 +83,7 @@ Since Bing only change their photo of the day every 24 hours, I will be optimize
 Description=Bing desktop wallpaper changer
 
 [Service]
-ExecStart=/path/to/bing_wallpapers.sh
+ExecStart=/path/to/main.py
 ```
 
 `bing.timer`

--- a/bing_wallpapers.sh
+++ b/bing_wallpapers.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-cd /path/to/Bing_Wallpapers
-./main.py

--- a/main.py
+++ b/main.py
@@ -6,6 +6,9 @@ import os
 import re
 import sys
 
+# replace /path/to/Bing_Wallpapers with the actual path to the Bing_Wallpapers folder
+path_to_Bing_Wallpapers="/path/to/Bing_Wallpapers"
+
 # wait computer internet connection
 os.system("sleep 10")
 
@@ -374,7 +377,8 @@ def main():
         summary = 'Error executing %s' % app_name
         body = err
         exit_status = 1
-     
+    
+    os.chdir(path_to_Bing_Wallpapers)
     icon = os.path.abspath("Bing.svg") 
     app_notification = Notify.Notification.new(summary, str(body), icon)
     app_notification.show()


### PR DESCRIPTION
As I've just found an elegant way to change the working directory in Python, I think that the bing_wallpapers.sh file is no longer unnecessary. Maybe removing this bash script would also make it easier to package the project for pip.