### PR TITLE
Fix a small conditional bug from last update

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ import re
 import sys
 
 # replace /path/to/Bing_Wallpapers with the actual path to the Bing_Wallpapers folder
-path_to_Bing_Wallpapers="/path/to/Bing_Wallpapers"
+path_to_Bing_Wallpapers="/home/pygeek03/bin/bing-desktop-wallpaper-changer"
 
 # wait computer internet connection
 os.system("sleep 10")
@@ -362,11 +362,8 @@ def main():
         download_path = get_download_path()
         init_dir(download_path)
         image_path = os.path.join(download_path, image_name)
-        if os.path.samefile(get_current_background_uri(), image_path):
-            summary = 'Bing Wallpaper unchanged'
-            body = ('%s already exists in Wallpaper directory' %
-                    image_metadata.find("copyright").text.encode('utf-8'))   
-        elif not os.path.isfile(image_path):
+        
+        if not os.path.isfile(image_path):
             urlretrieve(image_url, image_path)
             change_background(image_path)
             change_screensaver(image_path)
@@ -376,6 +373,12 @@ def main():
             text = str(image_name) + " -- " + str(body) + "\n"
             with open(download_path + "/image-details.txt", "a+") as myfile:
                 myfile.write(text)
+        
+        elif os.path.samefile(get_current_background_uri(), image_path):
+            summary = 'Bing Wallpaper unchanged'
+            body = ('%s already exists in Wallpaper directory' %
+                    image_metadata.find("copyright").text.encode('utf-8'))
+        
         else:
             change_background(image_path)
             change_screensaver(image_path)
@@ -383,9 +386,11 @@ def main():
             body = ('%s already exists in Wallpaper directory' %
                     image_metadata.find("copyright").text.encode('utf-8'))
         check_limit()
+        
     except Exception as err:
         summary = 'Error executing %s' % app_name
         body = err
+        print(body)
         exit_status = 1
     
     os.chdir(path_to_Bing_Wallpapers)

--- a/main.py
+++ b/main.py
@@ -6,8 +6,8 @@ import os
 import re
 import sys
 
-# replace /path/to/Bing_Wallpapers with the actual path to the Bing_Wallpapers folder
-path_to_Bing_Wallpapers="/home/pygeek03/bin/bing-desktop-wallpaper-changer"
+# replace /path/to/bing-desktop-wallpaper-changers with the actual path to the bing-desktop-wallpaper-changer folder
+path_to_Bing_Wallpapers="/path/to/bing-desktop-wallpaper-changer"
 
 # wait computer internet connection
 os.system("sleep 10")


### PR DESCRIPTION
Since the last update, if the picture of the day is not in folder BingWallpapers in the first place, an error occurs: 
`[Errno 2] No such file or directory: '//home/USER//BingWallpapers/20161119.jpg'`
This is because of the order of the conditions introduced in the last update. I have switched it so that the conditional clause from last update (which was the first one) is now the second one. I also added some line spaces, just for readability.
PS: Just fixed some mistakes on my part about the folder name.