### PR TITLE
Removed unnessecary encodings inside of strings

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,8 +7,7 @@ import re
 import sys
 
 # replace /path/to/bing-desktop-wallpaper-changers with the actual path to the bing-desktop-wallpaper-changer folder
-# path_to_Bing_Wallpapers="/path/to/bing-desktop-wallpaper-changer"
-path_to_Bing_Wallpapers="/home/paul/informatik/linux/bing-desktop-wallpaper-changer-mine"
+path_to_Bing_Wallpapers="/path/to/bing-desktop-wallpaper-changer"
 
 # wait computer internet connection
 os.system("sleep 10")

--- a/main.py
+++ b/main.py
@@ -7,7 +7,8 @@ import re
 import sys
 
 # replace /path/to/bing-desktop-wallpaper-changers with the actual path to the bing-desktop-wallpaper-changer folder
-path_to_Bing_Wallpapers="/path/to/bing-desktop-wallpaper-changer"
+# path_to_Bing_Wallpapers="/path/to/bing-desktop-wallpaper-changer"
+path_to_Bing_Wallpapers="/home/paul/informatik/linux/bing-desktop-wallpaper-changer-mine"
 
 # wait computer internet connection
 os.system("sleep 10")
@@ -368,7 +369,7 @@ def main():
             change_background(image_path)
             change_screensaver(image_path)
             summary = 'Bing Wallpaper updated successfully'
-            body = image_metadata.find("copyright").text.encode('utf-8')
+            body = image_metadata.find("copyright").text
 
             text = str(image_name) + " -- " + str(body) + "\n"
             with open(download_path + "/image-details.txt", "a+") as myfile:
@@ -377,14 +378,14 @@ def main():
         elif os.path.samefile(get_current_background_uri(), image_path):
             summary = 'Bing Wallpaper unchanged'
             body = ('%s already exists in Wallpaper directory' %
-                    image_metadata.find("copyright").text.encode('utf-8'))
+                    image_metadata.find("copyright").text)
         
         else:
             change_background(image_path)
             change_screensaver(image_path)
             summary = 'Wallpaper changed to current Bing wallpaper'
             body = ('%s already exists in Wallpaper directory' %
-                    image_metadata.find("copyright").text.encode('utf-8'))
+                    image_metadata.find("copyright").text)
         check_limit()
         
     except Exception as err:
@@ -395,7 +396,7 @@ def main():
     
     os.chdir(path_to_Bing_Wallpapers)
     icon = os.path.abspath("Bing.svg") 
-    app_notification = Notify.Notification.new(summary, str(body), icon)
+    app_notification = Notify.Notification.new(summary, body, icon)
     app_notification.show()
     sys.exit(exit_status)
 


### PR DESCRIPTION
The notifications were assembled using strings with encodings inside of them. Just too much. works better without them.