### PR TITLE
Fixed get_current_background_uri()

### DIFF
--- a/bin/main.py
+++ b/bin/main.py
@@ -138,6 +138,15 @@ def get_current_background_cinnamon_uri():
     path = gsettings.get_string('picture-uri')
     return path[6:]
 
+def get_current_background_uri():
+    source = Gio.SettingsSchemaSource.get_default()
+    cinnamon_exists = source.lookup('org.cinnamon.desktop.background', True)
+    if cinnamon_exists:
+        current = get_current_background_cinnamon_uri()
+    else:
+        current = get_current_background_gnome_uri()
+    return current
+
 def change_screensaver(filename):
     set_gsetting('org.gnome.desktop.screensaver', 'picture-uri',
                  get_file_uri(filename))


### PR DESCRIPTION
The previous commit removed this function without updating the reference to it, breaking the software in certain cases. I've put it back so that it works and properly checks for Gnome vs Cinnamon. Can't test on Cinnamon but it works on Gnome now.